### PR TITLE
Store width and height in struct

### DIFF
--- a/akf_reconstruction.m
+++ b/akf_reconstruction.m
@@ -50,7 +50,6 @@ function akf_reconstruction(DataName, deblur_option, ...
     %% load dataset
     image = []; events = [];    
     load_data_add = sprintf(['./data/' DataName '.mat']);
-    data = load(load_data_add);
     load(load_data_add, 'ct', 'events', 'exposure', 'f_Q', 'image', 'post_process', 'time_image');
     dims = load(load_data_add, 'height', 'width');
     


### PR DESCRIPTION
On MATLAB R2021a, references to `width` and `height` were calling the in-built `width(X)` and `height(X)` functions, rather than using the loaded variables. I simply moved those to a `dims` struct.